### PR TITLE
Additional fixes to make project blueprint work

### DIFF
--- a/catalog/landing-zone-lite/services.yaml
+++ b/catalog/landing-zone-lite/services.yaml
@@ -23,3 +23,15 @@ metadata:
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceID: cloudbilling.googleapis.com
+---
+apiVersion: serviceusage.cnrm.cloud.google.com/v1beta1
+kind: Service
+metadata:
+  name: management-project-id-resourcemanager # kpt-set: ${management-project-id}-resourcemanager
+  namespace: config-control # kpt-set: ${management-namespace}
+  annotations:
+    cnrm.cloud.google.com/blueprint: cnrm/landing-zone/v0.4.0
+    cnrm.cloud.google.com/deletion-policy: "abandon"
+    cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
+spec:
+  resourceID: cloudresourcemanager.googleapis.com

--- a/catalog/project/README.md
+++ b/catalog/project/README.md
@@ -13,7 +13,7 @@ folder-namespace       1
 management-namespace   2
 management-project-id  6
 networking-namespace   1
-project-id             18
+instance-project-id             18
 projects-namespace     3
 ```
 
@@ -24,8 +24,8 @@ projects-namespace     3
 ## Resources
 
 ```
-File          APIVersion                                     Kind     Name        Namespace
-project.yaml  resourcemanager.cnrm.cloud.google.com/v1beta1  Project  project-id  projects
+File          APIVersion                                     Kind     Name                 Namespace
+project.yaml  resourcemanager.cnrm.cloud.google.com/v1beta1  Project  instance-project-id  projects
 ```
 
 ## Resource References

--- a/catalog/project/kcc-namespace/README.md
+++ b/catalog/project/kcc-namespace/README.md
@@ -10,7 +10,7 @@ Setter                 Usages
 management-namespace   2
 management-project-id  6
 networking-namespace   1
-project-id             16
+instance-project-id    16
 projects-namespace     2
 ```
 
@@ -25,7 +25,7 @@ File                       APIVersion                          Kind             
 kcc-namespace-viewer.yaml  rbac.authorization.k8s.io/v1        RoleBinding             cnrm-network-viewer-project-id                     networking
 kcc-namespace-viewer.yaml  rbac.authorization.k8s.io/v1        RoleBinding             cnrm-project-viewer-project-id                     projects
 kcc-project-owner.yaml     iam.cnrm.cloud.google.com/v1beta1   IAMPartialPolicy         kcc-project-id-owners-permissions                  projects
-kcc.yaml                   core.cnrm.cloud.google.com/v1beta1  ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  project-id
+kcc.yaml                   core.cnrm.cloud.google.com/v1beta1  ConfigConnectorContext  configconnectorcontext.core.cnrm.cloud.google.com  projects
 kcc.yaml                   iam.cnrm.cloud.google.com/v1beta1   IAMPartialPolicy         project-id-sa-workload-identity-binding            config-control
 kcc.yaml                   iam.cnrm.cloud.google.com/v1beta1   IAMServiceAccount       kcc-project-id                                     config-control
 namespace.yaml             v1                                  Namespace               project-id

--- a/catalog/project/kcc-namespace/kcc-namespace-viewer.yaml
+++ b/catalog/project/kcc-namespace/kcc-namespace-viewer.yaml
@@ -16,14 +16,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cnrm-network-viewer-project-id # kpt-set: cnrm-network-viewer-${project-id}
+  name: cnrm-network-viewer-project-id # kpt-set: cnrm-network-viewer-${instance-project-id}
   namespace: networking # kpt-set: ${networking-namespace}
 roleRef:
   name: cnrm-viewer
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
 subjects:
-  - name: cnrm-controller-manager-project-id # kpt-set: cnrm-controller-manager-${project-id}
+  - name: cnrm-controller-manager-project-id # kpt-set: cnrm-controller-manager-${instace-project-id}
     namespace: cnrm-system
     kind: ServiceAccount
 ---
@@ -32,13 +32,13 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cnrm-project-viewer-project-id # kpt-set: cnrm-project-viewer-${project-id}
+  name: cnrm-project-viewer-project-id # kpt-set: cnrm-project-viewer-${instance-project-id}
   namespace: projects # kpt-set: ${projects-namespace}
 roleRef:
   name: cnrm-viewer
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
 subjects:
-  - name: cnrm-controller-manager-project-id # kpt-set: cnrm-controller-manager-${project-id}
+  - name: cnrm-controller-manager-project-id # kpt-set: cnrm-controller-manager-${instance-project-id}
     namespace: cnrm-system
     kind: ServiceAccount

--- a/catalog/project/kcc-namespace/kcc-project-owner.yaml
+++ b/catalog/project/kcc-namespace/kcc-project-owner.yaml
@@ -15,7 +15,7 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
-  name: kcc-project-id-owners-permissions # kpt-set: kcc-${project-id}-owners-permissions
+  name: kcc-project-id-owners-permissions # kpt-set: kcc-${instance-project-id}-owners-permissions
   namespace: projects # kpt-set: ${projects-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.0
@@ -24,8 +24,8 @@ spec:
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
-    external: project-id # kpt-set: ${project-id}
+    external: project-id # kpt-set: ${instance-project-id}
   bindings:
     - role: roles/owner
       members:
-        - member: serviceAccount:kcc-project-id@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:kcc-${project-id}@${management-project-id}.iam.gserviceaccount.com
+        - member: serviceAccount:kcc-project-id@management-project-id.iam.gserviceaccount.com # kpt-set: serviceAccount:kcc-${instance-project-id}@${management-project-id}.iam.gserviceaccount.com

--- a/catalog/project/kcc-namespace/kcc.yaml
+++ b/catalog/project/kcc-namespace/kcc.yaml
@@ -16,39 +16,39 @@ apiVersion: core.cnrm.cloud.google.com/v1beta1
 kind: ConfigConnectorContext
 metadata:
   name: configconnectorcontext.core.cnrm.cloud.google.com
-  namespace: project-id # kpt-set: ${project-id}
+  namespace: project-id # kpt-set: ${instance-project-id}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.0
 spec:
-  googleServiceAccount: kcc-project-id@management-project-id.iam.gserviceaccount.com # kpt-set: kcc-${project-id}@${management-project-id}.iam.gserviceaccount.com
+  googleServiceAccount: kcc-project-id@management-project-id.iam.gserviceaccount.com # kpt-set: kcc-${instance-project-id}@${management-project-id}.iam.gserviceaccount.com
 ---
 # Create GCP ServiceAccount for use by KCC to manage resources in this project
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
-  name: kcc-project-id # kpt-set: kcc-${project-id}
+  name: kcc-project-id # kpt-set: kcc-${instance-project-id}
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
-  displayName: kcc-project-id # kpt-set: kcc-${project-id}
+  displayName: kcc-project-id # kpt-set: kcc-${instance-project-id}
 ---
 # Allow KCC's Kubernetes Service Account to use the GCP ServiceAccount
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
-  name: project-id-sa-workload-identity-binding # kpt-set: ${project-id}-sa-workload-identity-binding
+  name: project-id-sa-workload-identity-binding # kpt-set: ${instance-project-id}-sa-workload-identity-binding
   namespace: config-control # kpt-set: ${management-namespace}
   annotations:
     cnrm.cloud.google.com/blueprint: cnrm/kcc-namespace/v0.4.0
     cnrm.cloud.google.com/project-id: management-project-id # kpt-set: ${management-project-id}
 spec:
   resourceRef:
-    name: kcc-project-id # kpt-set: kcc-${project-id}
+    name: kcc-project-id # kpt-set: kcc-${instance-project-id}
     apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
   bindings:
     - role: roles/iam.workloadIdentityUser
       members:
-        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-project-id] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-${project-id}]
+        - member: serviceAccount:management-project-id.svc.id.goog[cnrm-system/cnrm-controller-manager-project-id] # kpt-set: serviceAccount:${management-project-id}.svc.id.goog[cnrm-system/cnrm-controller-manager-${instance-project-id}]

--- a/catalog/project/kcc-namespace/namespace.yaml
+++ b/catalog/project/kcc-namespace/namespace.yaml
@@ -15,6 +15,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: project-id # kpt-set: ${project-id}
+  name: project-id # kpt-set: ${instance-project-id}
   annotations:
-    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${project-id}
+    cnrm.cloud.google.com/project-id: project-id # kpt-set: ${instance-project-id}

--- a/catalog/project/kcc-namespace/setters.yaml
+++ b/catalog/project/kcc-namespace/setters.yaml
@@ -22,5 +22,5 @@ data:
   management-namespace: config-control
   management-project-id: management-project-id
   networking-namespace: networking
-  project-id: project-id
+  instance-project-id: project-id
   projects-namespace: projects

--- a/catalog/project/project.yaml
+++ b/catalog/project/project.yaml
@@ -14,13 +14,13 @@
 apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
 kind: Project
 metadata:
-  name: project-id # kpt-set: ${project-id}
+  name: project-id # kpt-set: ${instance-project-id}
   namespace: projects # kpt-set: ${projects-namespace}
   annotations:
     cnrm.cloud.google.com/auto-create-network: "false"
     cnrm.cloud.google.com/blueprint: cnrm/landing-zone:project/v0.4.0
 spec:
-  name: project-id # kpt-set: ${project-id}
+  name: project-id # kpt-set: ${instance-project-id}
   billingAccountRef:
     external: "AAAAAA-BBBBBB-CCCCCC" # kpt-set: ${billing-account-id}
   folderRef:


### PR DESCRIPTION
Two fixes to make project blueprint work:

1. Change `project-id` setters to `instance-project-id`. Blueprints Controller automatically sets `project-id` on behalf of customers with the project that BC is enabled in. This will overwrite any setter values in the pipeline for `project-id`

2. Add resource manager as a service to be enabled on the project in order for the blueprint to work.